### PR TITLE
Fix Visual Mode scroll bug

### DIFF
--- a/lua/luxmotion/scroll/keymaps.lua
+++ b/lua/luxmotion/scroll/keymaps.lua
@@ -26,9 +26,8 @@ function M.visual_smooth_scroll(command, count)
   
   local target_line = scroll_movement.calculate_scroll_target(current_line, command, count)
   
-  visual_utils.exit_visual_mode()
-  
   local restore_visual = function()
+    visual_utils.exit_visual_mode()
     visual_utils.restore_selection(selection)
   end
   


### PR DESCRIPTION
for half page scrolling in visual mode the highlight was snapping back to the line the animation initiated at. 

Updated the order of when animation starts / stops