### PR TITLE
Fix the zz, zt and zb by checking the viewport topline change

### DIFF
--- a/lua/whisk/engine/orchestrator.lua
+++ b/lua/whisk/engine/orchestrator.lua
@@ -13,6 +13,13 @@ local function is_same_position(context, result)
   return context.cursor.line == result.cursor.line and context.cursor.col == result.cursor.col
 end
 
+local function is_same_viewport(context, result)
+  if not result.viewport or not result.viewport.topline then
+    return true
+  end
+  return context.viewport.topline == result.viewport.topline
+end
+
 function M.execute(motion_id, input)
   local motion = motions.get(motion_id)
   if not motion then
@@ -43,7 +50,7 @@ function M.execute(motion_id, input)
     return
   end
 
-  if is_same_position(context, result) then
+  if is_same_position(context, result) and is_same_viewport(context, result) then
     return
   end
 

--- a/tests/unit/engine/orchestrator_spec.lua
+++ b/tests/unit/engine/orchestrator_spec.lua
@@ -205,4 +205,23 @@ describe('engine/orchestrator', function()
     assert.equals(cursor_after_second[1], 2)
     assert.is_true(loop.is_running())
   end)
+
+  it('execute detects change in viewport', function()
+    local config = require('whisk.config')
+    config.update({ viewport = { topline = 0 } })
+
+    motions.register({
+      id = 'test_view_detect',
+      keys = { 's' },
+      modes = { 'n' },
+      traits = { 'scroll' },
+      category = 'scroll',
+      calculator = function(_)
+        return { viewport = { topline = 50 } }
+      end,
+    })
+
+    orchestrator.execute('test_view_detect', {})
+    assert.is_true(loop.is_running())
+  end)
 end)


### PR DESCRIPTION
There was a bug where the loop did not start if only the viewport.topline was changed by a motion which caused the zz, zb and zt commands to stop working.

PS: All the tests pass