### PR TITLE
test(orchestrator): tighten viewport-guard test setup and add negative path

### DIFF
--- a/tests/unit/engine/orchestrator_spec.lua
+++ b/tests/unit/engine/orchestrator_spec.lua
@@ -208,7 +208,7 @@ describe('engine/orchestrator', function()
 
   it('execute detects change in viewport', function()
     local config = require('whisk.config')
-    config.update({ viewport = { topline = 0 } })
+    config.update({ scroll = { enabled = true } })
 
     motions.register({
       id = 'test_view_detect',
@@ -223,5 +223,27 @@ describe('engine/orchestrator', function()
 
     orchestrator.execute('test_view_detect', {})
     assert.is_true(loop.is_running())
+  end)
+
+  it('execute does not start loop when cursor and viewport unchanged', function()
+    local config = require('whisk.config')
+    config.update({ scroll = { enabled = true } })
+
+    motions.register({
+      id = 'test_view_unchanged',
+      keys = { 't' },
+      modes = { 'n' },
+      traits = { 'scroll' },
+      category = 'scroll',
+      calculator = function(ctx)
+        return {
+          cursor = { line = ctx.cursor.line, col = ctx.cursor.col },
+          viewport = { topline = ctx.viewport.topline },
+        }
+      end,
+    })
+
+    orchestrator.execute('test_view_unchanged', {})
+    assert.is_false(loop.is_running())
   end)
 end)


### PR DESCRIPTION
## Summary
- Follow-up to #12. Replaces a stray `config.update({ viewport = { topline = 0 } })` in the new viewport-change test with `config.update({ scroll = { enabled = true } })`. The original write was a no-op against the config schema; the test passed only because `scroll.enabled` defaults to `true`.
- Adds a negative-path test asserting `loop.is_running()` is `false` when a calculator returns the current cursor and current viewport, locking in the AND semantics of the new combined guard in `is_same_position` + `is_same_viewport`.
- No production code changes.

## Test plan
- [x] `bash scripts/run_tests.sh` — 441/441 passing, including both the existing `execute detects change in viewport` and the new `execute does not start loop when cursor and viewport unchanged`.
